### PR TITLE
Bug fix: message queue was shared among websockets

### DIFF
--- a/WebSocket.js
+++ b/WebSocket.js
@@ -220,6 +220,9 @@ Ext.define('Ext.ux.WebSocket', {
      */
     constructor: function (cfg) {
         var me = this;
+        
+        // Prevent messageQueue to be shared among websockets.
+        me.messageQueue = [];
 
         // Raises an error if no url is given
         if (Ext.isEmpty(cfg)) {


### PR DESCRIPTION
The message queue was shared among websockets.
This is undesired behaviour since all websockets have their own purpose.
On the 'onopen' event it may send messages of another websocket.
This is what i mean: https://fiddle.sencha.com/#fiddle/lc4